### PR TITLE
Made timing work without cuda

### DIFF
--- a/isdf/eval/metrics.py
+++ b/isdf/eval/metrics.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import time
 import numpy as np
 from scipy.spatial import cKDTree as KDTree
 import trimesh
@@ -10,19 +11,30 @@ import torch
 
 
 def start_timing():
-    torch.cuda.synchronize()
-    start = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    start.record()
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+    else:
+        start = time.perf_counter()
+        end = None
     return start, end
 
 
 def end_timing(start, end):
-    torch.cuda.synchronize()
-    end.record()
-    # Waits for everything to finish running
-    torch.cuda.synchronize()
-    elapsed_time = start.elapsed_time(end)
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+        end.record()
+        # Waits for everything to finish running
+        torch.cuda.synchronize()
+        elapsed_time = start.elapsed_time(end)
+    else:
+        end = time.perf_counter()
+        elapsed_time = end - start
+        # Convert to milliseconds to have the same units
+        # as torch.cuda.Event.elapsed_time
+        elapsed_time = elapsed_time * 1000
     return elapsed_time
 
 


### PR DESCRIPTION
Previously, train.py would crash if run on a device that did not have access to cuda.